### PR TITLE
Support for all arguments in make_zim_file()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.1.0 [WIP]
 
-* added video module
+* added video module with reencode, presets, config builder and video file probing
+* `make_zim_file()` accepts extra kwargs for zimwriterfs
 
 # 1.0.6
 

--- a/src/zimscraperlib/zim.py
+++ b/src/zimscraperlib/zim.py
@@ -100,11 +100,26 @@ class ZimInfo(object):
         return arg_list
 
 
-def make_zim_file(build_dir, output_dir, zim_fname, zim_info):
-    """ runs zimwriterfs """
+def make_zim_file(build_dir, output_dir, zim_fname, zim_info, **kwargs):
+    """ runs zimwriterfs 
+    
+    The function takes in the following arguments
+        build_dir: The directory to convert into a ZIM file
+        output_dir: The directory where the ZIM file would be saved
+        zim_fname: The name of the ZIM file
+        zim_info: An object of class ZimInfo
+    
+    Also supports the following keyword arguments that are passed to to_zimwriterfs_args()
+        verbose: Use verbose mode while creating ZIM
+        inflateHtml: Whether try to inflate HTML files
+        uniqueNamespace: Put everything in namespace 'A'
+        withoutFTIndex: No fulltext index
+        minChunkSize: Number of bytes per ZIM cluster
+        redirects: Path to file containing redirects
+    """
     args = (
-        [ZimInfo.zimwriterfs_path]
-        + zim_info.to_zimwriterfs_args()
+        [zim_info.zimwriterfs_path]
+        + zim_info.to_zimwriterfs_args(**kwargs)
         + [str(build_dir), str(output_dir.joinpath(zim_fname))]
     )
 

--- a/src/zimscraperlib/zim.py
+++ b/src/zimscraperlib/zim.py
@@ -14,8 +14,6 @@ from .logging import nicer_args_join
 
 
 class ZimInfo(object):
-    zimwriterfs_path = os.getenv("ZIMWRITERFS_BINARY", "/usr/bin/zimwriterfs")
-
     def __init__(
         self,
         homepage="home.html",
@@ -101,24 +99,17 @@ class ZimInfo(object):
 
 
 def make_zim_file(build_dir, output_dir, zim_fname, zim_info, **kwargs):
-    """ runs zimwriterfs 
-    
-    The function takes in the following arguments
+    """ Creates a zim file using zimwriterfs
+
+    Arguments:
         build_dir: The directory to convert into a ZIM file
         output_dir: The directory where the ZIM file would be saved
         zim_fname: The name of the ZIM file
         zim_info: An object of class ZimInfo
-    
-    Also supports the following keyword arguments that are passed to to_zimwriterfs_args()
-        verbose: Use verbose mode while creating ZIM
-        inflateHtml: Whether try to inflate HTML files
-        uniqueNamespace: Put everything in namespace 'A'
-        withoutFTIndex: No fulltext index
-        minChunkSize: Number of bytes per ZIM cluster
-        redirects: Path to file containing redirects
-    """
+
+        **kwargs: passed directly to to_zimwriterfs_args() """
     args = (
-        [zim_info.zimwriterfs_path]
+        ["/usr/bin/env", "zimwriterfs"]
         + zim_info.to_zimwriterfs_args(**kwargs)
         + [str(build_dir), str(output_dir.joinpath(zim_fname))]
     )

--- a/tests/zim/test_zim.py
+++ b/tests/zim/test_zim.py
@@ -82,13 +82,14 @@ def test_zimwriterfs_command(monkeypatch, ziminfo):
     build_dir = pathlib.Path("build")
     output_dir = pathlib.Path("output")
     zim_fname = f"{ziminfo.name}.zim"
+    extras = {"uniqueNamespace": True, "withoutFTIndex": True}
 
     def mock_subprocess_run(args, **kwargs):
-        assert len(args) == 22
+        assert len(args) == 24
         assert args[-1].endswith(".zim")
         assert args[-1] == str(output_dir.joinpath(zim_fname))
         assert args[-2] == str(build_dir)
         return subprocess.CompletedProcess(args=args, returncode=0)
 
     monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-    make_zim_file(build_dir, output_dir, zim_fname, ziminfo)
+    make_zim_file(build_dir, output_dir, zim_fname, ziminfo, **extras)

--- a/tests/zim/test_zim.py
+++ b/tests/zim/test_zim.py
@@ -85,7 +85,7 @@ def test_zimwriterfs_command(monkeypatch, ziminfo):
     extras = {"uniqueNamespace": True, "withoutFTIndex": True}
 
     def mock_subprocess_run(args, **kwargs):
-        assert len(args) == 24
+        assert len(args) == 25
         assert args[-1].endswith(".zim")
         assert args[-1] == str(output_dir.joinpath(zim_fname))
         assert args[-2] == str(build_dir)


### PR DESCRIPTION
Fixes #20 by making make_zim_file() take in kwargs which are passed to to_zimwriterfs_args(). Also, made it take the zimwriterfs binary location from the object of ZimInfo that's passed as it would allow to change it easily if required. Also added some docstrings regarding the arguments.

This one changes the API