### PR TITLE
Better image resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # dev
 
-* expose reencode, Config and get_media_info in zimscraperlib.video
+* exposed reencode, Config and get_media_info in zimscraperlib.video
+* added save_image() and convert_image() in zimscraperlib.imaging
+* added support for upscaling in resize_image() via allow_upscaling
+* resize_image() now supports params given by user and preservs image colorspace
+* fixed tests for zimscraperlib.imaging
 
 # 1.1.0
 

--- a/src/zimscraperlib/imaging.py
+++ b/src/zimscraperlib/imaging.py
@@ -45,22 +45,18 @@ def alpha_not_supported():
     return ["JPEG", "BMP", "EPS", "PCX"]
 
 
-def save_image(image, dst, fmt, params=None):
-    """ saves an image with given format and default args and overrides them if params are given 
-        params: PIL params as dict (https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html) """
+def save_image(image, dst, fmt, **params):
+    """ saves an image with default args and overrides them if params are given 
+        params: PIL params (https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html) """
     default_args = {"JPEG": {"quality": 100}, "PNG": {}}
-    args = params if params else default_args.get(fmt, {})
+    args = default_args.get(fmt, {})
+    if params:
+        args.update(params)
     image.save(dst, fmt, **args)
 
 
 def resize_image(
-    fpath,
-    width,
-    height=None,
-    to=None,
-    method="width",
-    allow_upscaling=True,
-    params=None,
+    fpath, width, height=None, to=None, method="width", allow_upscaling=True, **params,
 ):
     """ resize an image file (dimensions)
 
@@ -91,10 +87,10 @@ def resize_image(
     if resized.mode == "RGBA" and image_format in alpha_not_supported():
         resized = resized.convert(image_mode)
     # save the image
-    save_image(resized, str(to) if to is not None else fpath, image_format, params)
+    save_image(resized, str(to) if to is not None else fpath, image_format, **params)
 
 
-def convert_image(src, dst, target_format, colorspace=None, params=None):
+def convert_image(src, dst, target_format, colorspace=None, **params):
     """ convert an image file from one format to another 
 
         colorspace: RGB, ARGB, CMYK (and other PIL colorspaces)
@@ -107,7 +103,7 @@ def convert_image(src, dst, target_format, colorspace=None, params=None):
             dst_image = (
                 image.convert("RGB") if not colorspace else image.convert(colorspace)
             )
-    save_image(dst_image, dst, target_format, params)
+    save_image(dst_image, dst, target_format, **params)
 
 
 def is_hex_color(text):

--- a/src/zimscraperlib/imaging.py
+++ b/src/zimscraperlib/imaging.py
@@ -10,6 +10,9 @@ import colorthief
 from resizeimage import resizeimage
 
 
+alpha_not_supported = ["JPEG", "BMP", "EPS", "PCX"]
+
+
 def get_colors(image_path, use_palette=True):
     """ (main, secondary) HTML color codes from an image path """
 
@@ -38,11 +41,6 @@ def get_colors(image_path, use_palette=True):
         sr, sg, sb = solarize(mr, mg, mb)
 
     return rgb_to_hex(mr, mg, mb), rgb_to_hex(sr, sg, sb)
-
-
-def alpha_not_supported():
-    """ list of PIL image formats which do not support alpha layer """
-    return ["JPEG", "BMP", "EPS", "PCX"]
 
 
 def save_image(image, dst, fmt, **params):
@@ -84,7 +82,7 @@ def resize_image(
             resized = resizeimage.resize(method, image, [width, height])
 
     # remove alpha layer if not supported and added during resizing
-    if resized.mode == "RGBA" and image_format in alpha_not_supported():
+    if resized.mode == "RGBA" and image_format in alpha_not_supported:
         resized = resized.convert(image_mode)
     # save the image
     save_image(resized, str(to) if to is not None else fpath, image_format, **params)
@@ -98,7 +96,7 @@ def convert_image(src, dst, target_format, colorspace=None, **params):
     with PIL.Image.open(src) as image:
         dst_image = image
         if (
-            image.mode == "RGBA" and target_format in alpha_not_supported()
+            image.mode == "RGBA" and target_format in alpha_not_supported
         ) or colorspace:
             dst_image = (
                 image.convert("RGB") if not colorspace else image.convert(colorspace)

--- a/src/zimscraperlib/imaging.py
+++ b/src/zimscraperlib/imaging.py
@@ -40,21 +40,40 @@ def get_colors(image_path, use_palette=True):
     return rgb_to_hex(mr, mg, mb), rgb_to_hex(sr, sg, sb)
 
 
-def resize_image(fpath, width, height=None, to=None, method="width"):
+def resize_image(
+    fpath, width, height=None, to=None, method="width", allow_upscaling=True
+):
     """ resize an image file (dimensions)
 
-        methods: width, height, cover """
+        methods: width, height, cover
+        allow upscaling: upscale image preserving aspect ratio if required before resizing """
     with open(str(fpath), "rb") as fp:
-        with PIL.Image.open(fp) as image:
-            if method == "width":
-                resized = resizeimage.resize(method, image, width)
-            elif method == "height":
-                resized = resizeimage.resize(method, image, height)
-            else:
-                resized = resizeimage.resize(method, image, [width, height])
+        image = PIL.Image.open(fp)
+        # prserve image format
+        image_format = image.format
+
+        # upscale if required preserving the aspect ratio
+        if allow_upscaling:
+            height_width_ratio = float(image.size[1]) / float(image.size[0])
+            if image.size[0] < width:
+                image = image.resize((width, int(width * height_width_ratio)))
+            if height and image.size[1] < height:
+                image = image.resize((int(height / height_width_ratio), height))
+
+        # resize using the requested method
+        if method == "width":
+            resized = resizeimage.resize(method, image, width)
+        elif method == "height":
+            resized = resizeimage.resize(method, image, height)
+        else:
+            resized = resizeimage.resize(method, image, [width, height])
+
+    # save the image
+    if resized.mode == "RGBA" and image_format == "JPEG":
+        resized = resized.convert("RGB")
     kwargs = {"JPEG": {"quality": 100}, "PNG": {}}
     resized.save(
-        str(to) if to is not None else fpath, image.format, **kwargs.get(image.format)
+        str(to) if to is not None else fpath, image_format, **kwargs.get(image_format)
     )
 
 

--- a/src/zimscraperlib/imaging.py
+++ b/src/zimscraperlib/imaging.py
@@ -10,7 +10,7 @@ import colorthief
 from resizeimage import resizeimage
 
 
-alpha_not_supported = ["JPEG", "BMP", "EPS", "PCX"]
+ALPHA_NOT_SUPPORTED = ["JPEG", "BMP", "EPS", "PCX"]
 
 
 def get_colors(image_path, use_palette=True):
@@ -80,7 +80,7 @@ def resize_image(
             resized = resizeimage.resize(method, image, [width, height])
 
     # remove alpha layer if not supported and added during resizing
-    if resized.mode == "RGBA" and image_format in alpha_not_supported:
+    if resized.mode == "RGBA" and image_format in ALPHA_NOT_SUPPORTED:
         resized = resized.convert(image_mode)
     # save the image
     save_image(resized, str(to) if to is not None else fpath, image_format, **params)
@@ -94,7 +94,7 @@ def convert_image(src, dst, target_format, colorspace=None, **params):
     with PIL.Image.open(src) as image:
         dst_image = image
         if (
-            image.mode == "RGBA" and target_format in alpha_not_supported
+            image.mode == "RGBA" and target_format in ALPHA_NOT_SUPPORTED
         ) or colorspace:
             dst_image = (
                 image.convert("RGB") if not colorspace else image.convert(colorspace)

--- a/src/zimscraperlib/imaging.py
+++ b/src/zimscraperlib/imaging.py
@@ -44,12 +44,10 @@ def get_colors(image_path, use_palette=True):
 
 
 def save_image(image, dst, fmt, **params):
-    """ saves an image with default args and overrides them if params are given 
+    """ saves an image with default args and overrides them if params are given
         params: PIL params (https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html) """
-    default_args = {"JPEG": {"quality": 100}, "PNG": {}}
-    args = default_args.get(fmt, {})
-    if params:
-        args.update(params)
+    args = {"JPEG": {"quality": 100}, "PNG": {}}.get(fmt, {})
+    args.update(params or {})
     image.save(dst, fmt, **args)
 
 
@@ -89,7 +87,7 @@ def resize_image(
 
 
 def convert_image(src, dst, target_format, colorspace=None, **params):
-    """ convert an image file from one format to another 
+    """ convert an image file from one format to another
 
         colorspace: RGB, ARGB, CMYK (and other PIL colorspaces)
         target_format: JPEG, PNG, BMP (and other PIL formats) """

--- a/tests/imaging/test_imaging.py
+++ b/tests/imaging/test_imaging.py
@@ -77,7 +77,10 @@ def test_alpha_not_supported():
 def test_save_image(png_image, jpg_image, tmp_path, fmt, params):
     src, dst = get_src_dst(png_image, jpg_image, tmp_path, fmt)
     img = Image.open(src)
-    save_image(img, dst, "JPEG" if fmt == "jpg" else fmt, params)
+    if params:
+        save_image(img, dst, "JPEG" if fmt == "jpg" else fmt, **params)
+    else:
+        save_image(img, dst, "JPEG" if fmt == "jpg" else fmt)
     assert pathlib.Path(dst).exists()
 
 

--- a/tests/imaging/test_imaging.py
+++ b/tests/imaging/test_imaging.py
@@ -14,7 +14,7 @@ from zimscraperlib.imaging import (
     resize_image,
     create_favicon,
     convert_image,
-    alpha_not_supported,
+    ALPHA_NOT_SUPPORTED,
     save_image,
 )
 

--- a/tests/imaging/test_imaging.py
+++ b/tests/imaging/test_imaging.py
@@ -14,7 +14,6 @@ from zimscraperlib.imaging import (
     resize_image,
     create_favicon,
     convert_image,
-    ALPHA_NOT_SUPPORTED,
     save_image,
 )
 

--- a/tests/imaging/test_imaging.py
+++ b/tests/imaging/test_imaging.py
@@ -5,6 +5,7 @@
 import pytest
 
 from PIL import Image
+from resizeimage.imageexceptions import ImageSizeError
 
 from zimscraperlib.imaging import get_colors, is_hex_color, resize_image, create_favicon
 
@@ -64,7 +65,7 @@ def test_resize_thumbnail(png_image, jpg_image, tmp_path, fmt):
     src, dst = get_src_dst(png_image, jpg_image, tmp_path, fmt)
 
     width, height = 100, 50
-    resize_image(png_image, width, height, to=dst, method="thumbnail")
+    resize_image(src, width, height, to=dst, method="thumbnail")
     tw, th = get_image_size(dst)
     assert tw <= width
     assert th <= height
@@ -77,8 +78,8 @@ def test_resize_width(png_image, jpg_image, tmp_path, fmt):
     src, dst = get_src_dst(png_image, jpg_image, tmp_path, fmt)
 
     width, height = 100, 50
-    resize_image(png_image, width, height, to=dst, method="width")
-    tw, th = get_image_size(dst)
+    resize_image(src, width, height, to=dst, method="width")
+    tw, _ = get_image_size(dst)
     assert tw == width
 
 
@@ -89,8 +90,8 @@ def test_resize_height(png_image, jpg_image, tmp_path, fmt):
     src, dst = get_src_dst(png_image, jpg_image, tmp_path, fmt)
 
     width, height = 100, 50
-    resize_image(png_image, width, height, to=dst, method="height")
-    tw, th = get_image_size(dst)
+    resize_image(src, width, height, to=dst, method="height")
+    _, th = get_image_size(dst)
     assert th == height
 
 
@@ -101,10 +102,10 @@ def test_resize_crop(png_image, jpg_image, tmp_path, fmt):
     src, dst = get_src_dst(png_image, jpg_image, tmp_path, fmt)
 
     width, height = 5, 50
-    resize_image(png_image, width, height, to=dst, method="crop")
+    resize_image(src, width, height, to=dst, method="crop")
     tw, th = get_image_size(dst)
-    assert tw <= width
-    assert th <= height
+    assert tw == width
+    assert th == height
 
 
 @pytest.mark.parametrize(
@@ -114,10 +115,10 @@ def test_resize_cover(png_image, jpg_image, tmp_path, fmt):
     src, dst = get_src_dst(png_image, jpg_image, tmp_path, fmt)
 
     width, height = 5, 50
-    resize_image(png_image, width, height, to=dst, method="cover")
+    resize_image(src, width, height, to=dst, method="cover")
     tw, th = get_image_size(dst)
-    assert tw <= width
-    assert th <= height
+    assert tw == width
+    assert th == height
 
 
 @pytest.mark.parametrize(
@@ -127,10 +128,34 @@ def test_resize_contain(png_image, jpg_image, tmp_path, fmt):
     src, dst = get_src_dst(png_image, jpg_image, tmp_path, fmt)
 
     width, height = 5, 50
-    resize_image(png_image, width, height, to=dst, method="contain")
+    resize_image(src, width, height, to=dst, method="contain")
     tw, th = get_image_size(dst)
     assert tw <= width
     assert th <= height
+
+
+@pytest.mark.parametrize(
+    "fmt", ["png", "jpg"],
+)
+def test_resize_upscale(png_image, jpg_image, tmp_path, fmt):
+    src, dst = get_src_dst(png_image, jpg_image, tmp_path, fmt)
+
+    width, height = 500, 1000
+    resize_image(src, width, height, to=dst, method="cover")
+    tw, th = get_image_size(dst)
+    assert tw == width
+    assert th == height
+
+
+@pytest.mark.parametrize(
+    "fmt", ["png", "jpg"],
+)
+def test_resize_small_image_error(png_image, jpg_image, tmp_path, fmt):
+    src, dst = get_src_dst(png_image, jpg_image, tmp_path, fmt)
+
+    width, height = 500, 1000
+    with pytest.raises(ImageSizeError):
+        resize_image(src, width, height, to=dst, method="cover", allow_upscaling=False)
 
 
 @pytest.mark.parametrize(

--- a/tests/imaging/test_imaging.py
+++ b/tests/imaging/test_imaging.py
@@ -67,10 +67,6 @@ def test_colors_jpg_palette(jpg_image):
     assert get_colors(jpg_image, True) == ("#221C1B", "#F4F3F1")
 
 
-def test_alpha_not_supported():
-    assert alpha_not_supported() == ["JPEG", "BMP", "EPS", "PCX"]
-
-
 @pytest.mark.parametrize(
     "fmt,params", [("png", None), ("jpg", {"quality": 50})],
 )

--- a/tests/imaging/test_imaging.py
+++ b/tests/imaging/test_imaging.py
@@ -7,7 +7,13 @@ import pytest
 from PIL import Image
 from resizeimage.imageexceptions import ImageSizeError
 
-from zimscraperlib.imaging import get_colors, is_hex_color, resize_image, create_favicon
+from zimscraperlib.imaging import (
+    get_colors,
+    is_hex_color,
+    resize_image,
+    create_favicon,
+    change_image_format,
+)
 
 
 def get_image_size(fpath):
@@ -156,6 +162,22 @@ def test_resize_small_image_error(png_image, jpg_image, tmp_path, fmt):
     width, height = 500, 1000
     with pytest.raises(ImageSizeError):
         resize_image(src, width, height, to=dst, method="cover", allow_upscaling=False)
+
+
+@pytest.mark.parametrize(
+    "src_fmt,dst_fmt,colorspace",
+    [("png", "JPEG", "RGB"), ("png", "BMP", None), ("jpg", "JPEG", "CMYK")],
+)
+def test_change_image_format(
+    png_image, jpg_image, tmp_path, src_fmt, dst_fmt, colorspace
+):
+    src, _ = get_src_dst(png_image, jpg_image, tmp_path, src_fmt)
+    dst = tmp_path / f"out.{dst_fmt.lower()}"
+    change_image_format(src, dst, dst_fmt, colorspace=colorspace)
+    dst_image = Image.open(dst)
+    if colorspace:
+        assert dst_image.mode == colorspace
+    assert dst_image.format == dst_fmt
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Contains the following changes -
- added argument allow_upscaling to upscale image if it cannot be resized due to smaller dimentions than required
- use src instead of png_image in tests
- use _ for unused variables in tests
- add tests for allow_upscaling
- convert image to RGB if saving as JPEG

Also, this would fix https://github.com/openzim/youtube/issues/104

This is compatible with the previous API but contains an extra option allow_upscaling