### PR TITLE
Fix zim url rewritting on node without expected attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 1.2.1.dev0
 
 * fixed URL rewriting when running from /
+* added support for link rewriting in <object> element
+* prevent from raising error if element doesn't have the attribute with url
 
 # 1.2.0
 

--- a/src/zimscraperlib/zim/rewriting.py
+++ b/src/zimscraperlib/zim/rewriting.py
@@ -134,6 +134,11 @@ def fix_links_in_html(url: str, content: str) -> str:
     soup = BeautifulSoup(content, "html.parser")
     for nodename, key in mapping.items():
         for node in soup.find_all(nodename):
+
+            # do nothing if the required attribute is not found in the tag
+            if not node.has_attr(key):
+                continue
+
             html_link = node.attrs[key]
 
             # parse as a URL to extract querystring and fragment

--- a/src/zimscraperlib/zim/rewriting.py
+++ b/src/zimscraperlib/zim/rewriting.py
@@ -130,6 +130,7 @@ def fix_links_in_html(url: str, content: str) -> str:
         "img": "src",
         "track": "src",
         "video": "poster",
+        "object": "data",
     }
     soup = BeautifulSoup(content, "html.parser")
     for nodename, key in mapping.items():

--- a/tests/zim/conftest.py
+++ b/tests/zim/conftest.py
@@ -33,6 +33,7 @@ def html_str():
     <li><a href="download/toto.txt">text file</a></li>
     <li><a href="dest.html">HTML link</a></li>
     <li><a href="no-extension">no ext link</a></li>
+    <li><a media="">no href link</a></li>
 <script src="assets/js/bootstrap/bootsrap.css?v=20190101"></script>
 </body>
 </html>

--- a/tests/zim/conftest.py
+++ b/tests/zim/conftest.py
@@ -34,6 +34,7 @@ def html_str():
     <li><a href="dest.html">HTML link</a></li>
     <li><a href="no-extension">no ext link</a></li>
     <li><a media="">no href link</a></li>
+<object data="download/toto.jpg" width="300" height="200"></object>
 <script src="assets/js/bootstrap/bootsrap.css?v=20190101"></script>
 </body>
 </html>

--- a/tests/zim/test_rewriting.py
+++ b/tests/zim/test_rewriting.py
@@ -156,7 +156,7 @@ def test_fix_target_for(tmp_path, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "pattern, expected_count", [("../A/", 2), ("../I/", 1), ("../-/", 2)],
+    "pattern, expected_count", [("../A/", 2), ("../I/", 2), ("../-/", 2)],
 )
 def test_fix_links_in_html(html_str, pattern, expected_count):
     assert fix_links_in_html("A/welcome", html_str).count(pattern) == expected_count
@@ -193,7 +193,7 @@ def test_fix_links_in_html_file(tmp_path, html_str):
 
 
 @pytest.mark.parametrize(
-    "pattern, expected_count", [("../A/", 2), ("../I/", 1), ("../-/", 2)],
+    "pattern, expected_count", [("../A/", 2), ("../I/", 2), ("../-/", 2)],
 )
 def test_fix_links_in_html_file2(html_file, pattern, expected_count):
     # make sure not-in place rewrites properly

--- a/tests/zim/test_zim_creator.py
+++ b/tests/zim/test_zim_creator.py
@@ -96,7 +96,7 @@ def test_zim_creator(tmp_path, png_image, css_file, html_file, css_str, html_str
         assert count_links(reader.get_article("A/welcome"), r"../A") == 2
         assert count_links(reader.get_article("A/welcome"), r"../-") == 2
         assert count_links(reader.get_article("A/welcome"), r"dest.html") == 1
-        assert count_links(reader.get_article("A/welcome3"), r"../I") == 1
+        assert count_links(reader.get_article("A/welcome3"), r"../I") == 2
         assert count_links(reader.get_article("A/welcome3"), r"../-") == 2
         assert count_links(reader.get_article("A/welcome3"), r"../A") == 2
         assert count_links(reader.get_article("A/welcome3"), r"dest.html") == 1


### PR DESCRIPTION
This prevents KeyError while rewriting links if the HTML tag doesn't contain the attribute holding the link. For example, <a> tags without href are still valid.

Also adds object element link rewriting if data attribute contains a link.