### PR TITLE
Get language from HTML

### DIFF
--- a/tests/zim/test_rewriting.py
+++ b/tests/zim/test_rewriting.py
@@ -13,6 +13,8 @@ from zimscraperlib.zim.rewriting import (
     find_url,
     find_title_in,
     find_title_in_file,
+    find_language_in,
+    find_language_in_file,
     get_base64_src_of,
     relative_dots,
     fix_target_for,
@@ -94,6 +96,57 @@ def test_find_title(tmp_path, html_page):
     assert find_title_in_file(fpath, "text/plain") == ""
     # make sure incorrect filepath returns no title
     assert find_title_in_file(tmp_path / "nope", "text/html") == ""
+
+
+def test_find_language(tmp_path, html_page):
+    # find language in example HTML
+    assert find_language_in(html_page, "text/html") == "en-US"
+    # make sure non-HTML returns no language
+    assert find_language_in(html_page, "text/plain") == ""
+    # make sure non-html, even if using html mime returns no language
+    assert find_language_in("lang: en-US", "text/html") == ""
+    # make sure meta without http-equiv="content-language" returns no language
+    assert (
+        find_language_in(
+            "<html><head><meta content='en-UK'></head><body></body></html>", "text/html"
+        )
+        == ""
+    )
+
+    # find language in local file
+    fpath = tmp_path / "test.html"
+    with open(fpath, "w") as fh:
+        fh.write(html_page)
+    assert find_language_in_file(fpath, "text/html") == "en-US"
+    # make sure non-HTML returns no language (from file)
+    assert find_language_in_file(fpath, "text/plain") == ""
+    # make sure incorrect filepath returns no language
+    assert find_language_in_file(tmp_path / "nope", "text/html") == ""
+
+
+@pytest.mark.parametrize(
+    "html_string, expected_language",
+    [
+        (
+            "<html lang='en-US' xml:lang='zh-CN'><head><meta http-equiv='content-language' content='en-UK'></head><body lang='hi-IN'></body></html>",
+            "en-US",
+        ),
+        (
+            "<html xml:lang='en-US'><head><meta http-equiv='content-language' content='en-UK'></head><body lang='hi-IN'></body></html>",
+            "en-US",
+        ),
+        (
+            "<html><head><meta http-equiv='content-language' content='en-UK'></head><body lang='hi-IN'></body></html>",
+            "hi-IN",
+        ),
+        (
+            "<html><head><meta http-equiv='content-language' content='en-UK'></head><body></body></html>",
+            "en-UK",
+        ),
+    ],
+)
+def test_find_language_order(html_string, expected_language):
+    assert find_language_in(html_string, "text/html") == expected_language
 
 
 def test_get_base64_src_of(tmp_path, png_image, jpg_image):


### PR DESCRIPTION
This fixes #35 by implementing the following two functions in `zimscraperlib.zim.rewriting` -
- `find_language_in()` - Finds the language using the order mentioned in #35
- `find_language_in_file()` - Finds the language using `find_language_in()` from a file

Tests are also implemented for the same.