### PR TITLE
Use mimetypes guessed from filenames for text files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.2.2.dev0
 
-* n/a
+* detect mimetypes from filenames for all text files
 
 # 1.2.1
 

--- a/src/zimscraperlib/zim/filesystem.py
+++ b/src/zimscraperlib/zim/filesystem.py
@@ -66,7 +66,7 @@ class FileArticle(libzim.writer.Article):
         # first look inside the file's magic headers
         self.mime_type = get_file_mimetype(self.fpath)
         # most web-specific files are plain text. In this case, use extension
-        if self.mime_type == "text/plain":
+        if self.mime_type.startswith("text/"):
             self.mime_type = get_mime_for_name(self.fpath)
 
     def get_url(self) -> str:


### PR DESCRIPTION
This fixes #38 by using mimetypes guessed from filenames for the files reported as text (and not just text/plain) by magic.