### PR TITLE
Fixed StaticArticle usage with content=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.2.2.dev0
 
 * detect mimetypes from filenames for all text files
+* fixed non-filename based StaticArticle
 
 # 1.2.1
 

--- a/src/zimscraperlib/zim/creator.py
+++ b/src/zimscraperlib/zim/creator.py
@@ -178,7 +178,7 @@ class Creator(libzim.writer.Creator):
             StaticArticle(
                 url=to_longurl(namespace, url),
                 mime_type=mime_type,
-                filename=str(fpath),
+                filename=str(fpath) if fpath is not None else None,
                 content=content,
                 index=should_index,
                 compress=should_compress,


### PR DESCRIPTION
When using StaticArticle without a filename (`content=`) get_data() should return
the passed content bytes.
This behavior is toggled based on the result of `get_filename()`.
Casting to `str` the filename argument resulted in get_filename() to return `"None"`
fooling it into thinking it's a filename based StaticArticle