### PR TITLE
Rewrite links from poster attribute of audio element when creating ZIMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * detect mimetypes from filenames for all text files
 * fixed non-filename based StaticArticle
+* enable rewriting of links in poster attribute of audio element
+* added find_language_in() and find_language_in_file() to get language from HTML content and HTML file respectively
 
 # 1.2.1
 

--- a/src/zimscraperlib/zim/rewriting.py
+++ b/src/zimscraperlib/zim/rewriting.py
@@ -164,6 +164,7 @@ def fix_links_in_html(url: str, content: str) -> str:
         "img": "src",
         "track": "src",
         "video": "poster",
+        "audio": "poster",
         "object": "data",
     }
     soup = BeautifulSoup(content, "html.parser")


### PR DESCRIPTION
This allows rewriting of links in poster attribute of <audio> element used by videojs audio player. 

Unrelated - Added changelog for language extraction from HTML content and file as I didn't put it in that PR.