### PR TITLE
Better defaults for convert_image()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * enable rewriting of links in poster attribute of audio element
 * added find_language_in() and find_language_in_file() to get language from HTML content and HTML file respectively
 * add a mime mapping to deal with inconsistencies in mimetypes detected by magic on different platforms
+* convert_image signature changed:
+  * `target_format` positional argument removed. Replaced with optionnal `fmt` key of keyword arguments.
+  * `colorspace` optionnal positional argument removed. Replaced with optionnal `colorspace` key of keyword arguments.
 
 # 1.2.1
 

--- a/src/zimscraperlib/download.py
+++ b/src/zimscraperlib/download.py
@@ -2,14 +2,11 @@
 # -*- coding: utf-8 -*-
 # vim: ai ts=4 sts=4 et sw=4 nu
 
-import os
 import subprocess
 
 import requests
 
 from . import logger
-
-WGET_BINARY = os.getenv("WGET_BINARY", "/usr/bin/wget")
 
 
 def save_file(url, fpath, timeout=30, retries=5):
@@ -36,7 +33,8 @@ def save_large_file(url, fpath):
     """ download a binary file from its URL, using wget """
     subprocess.run(
         [
-            WGET_BINARY,
+            "/usr/bin/env",
+            "wget",
             "-t",
             "5",
             "--retry-connrefused",

--- a/tests/imaging/test_imaging.py
+++ b/tests/imaging/test_imaging.py
@@ -195,6 +195,21 @@ def test_change_image_format(
     assert dst_image.format == dst_fmt
 
 
+def test_change_image_format_defaults(png_image, jpg_image, tmp_path):
+    # PNG to JPEG (loosing alpha)
+    dst = tmp_path.joinpath(png_image.with_suffix(".jpg"))
+    convert_image(png_image, dst)
+    dst_image = Image.open(dst)
+    assert dst_image.mode == "RGB"
+    assert dst_image.format == "JPEG"
+    # PNG to WebP (keeping alpha)
+    dst = tmp_path.joinpath(png_image.with_suffix(".webp"))
+    convert_image(png_image, dst)
+    dst_image = Image.open(dst)
+    assert dst_image.mode == "RGBA"
+    assert dst_image.format == "WEBP"
+
+
 @pytest.mark.parametrize(
     "fmt,exp_size", [("png", 128), ("jpg", 128)],
 )

--- a/tests/imaging/test_imaging.py
+++ b/tests/imaging/test_imaging.py
@@ -188,7 +188,7 @@ def test_change_image_format(
 ):
     src, _ = get_src_dst(png_image, jpg_image, tmp_path, src_fmt)
     dst = tmp_path / f"out.{dst_fmt.lower()}"
-    convert_image(src, dst, dst_fmt, colorspace=colorspace)
+    convert_image(src, dst, fmt=dst_fmt, colorspace=colorspace)
     dst_image = Image.open(dst)
     if colorspace:
         assert dst_image.mode == colorspace


### PR DESCRIPTION
Pillow automatically uses the destination filename extension to guess format when saving
an Image. It seems odd that we require the destination format separately.

With this, the format is now optionnal (as `fmt` arg). It is also normalized as Pillow
uses all-upercase formats.

`colorspace` argument is also moved to keyword arguments as its use is unlikely while
setting save parameters should be a lot more common.