### PR TITLE
Do not rewrite mailto: links while creating ZIM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * convert_image signature changed:
   * `target_format` positional argument removed. Replaced with optionnal `fmt` key of keyword arguments.
   * `colorspace` optionnal positional argument removed. Replaced with optionnal `colorspace` key of keyword arguments.
+* prevent rewriting of `mailto:` links in rewriting.py
 
 # 1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * convert_image signature changed:
   * `target_format` positional argument removed. Replaced with optionnal `fmt` key of keyword arguments.
   * `colorspace` optionnal positional argument removed. Replaced with optionnal `colorspace` key of keyword arguments.
-* prevent rewriting of `mailto:` links in rewriting.py
+* prevent rewriting of `mailto:` links in HTML links rewriting
 
 # 1.2.1
 

--- a/src/zimscraperlib/zim/rewriting.py
+++ b/src/zimscraperlib/zim/rewriting.py
@@ -177,6 +177,10 @@ def fix_links_in_html(url: str, content: str) -> str:
 
             html_link = node.attrs[key]
 
+            # do not parse mailto: links
+            if html_link.startswith("mailto:"):
+                continue
+
             # parse as a URL to extract querystring and fragment
             _, netloc, target, query, fragment = urllib.parse.urlsplit(html_link)
 

--- a/tests/zim/conftest.py
+++ b/tests/zim/conftest.py
@@ -34,6 +34,7 @@ def html_str():
     <li><a href="dest.html">HTML link</a></li>
     <li><a href="no-extension">no ext link</a></li>
     <li><a href="http://www.example.com/index/sample.html">external link</a></li>
+    <li><a href="mailto:example@example.com">e-mail link</a></li>
     <li><a media="">no href link</a></li>
 <object data="download/toto.jpg" width="300" height="200"></object>
 <script src="assets/js/bootstrap/bootsrap.css?v=20190101"></script>


### PR DESCRIPTION
This disables link rewriting for `mailto:` links and hence fixes #46.