### PR TITLE
Fix rewriting of links with empty target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.3.2.dev0
 
-* n/a
+* fixed rewriting of links with empty target
 
 # 1.3.1
 

--- a/src/zimscraperlib/zim/rewriting.py
+++ b/src/zimscraperlib/zim/rewriting.py
@@ -186,7 +186,7 @@ def fix_links_in_html(url: str, content: str) -> str:
 
             # use source as target if there's none
             if not target:
-                target = str(url)[2:]  # without namespace
+                target = pathlib.Path(url).name  # only the filename
 
             fixed = fix_target_for(
                 pathlib.Path("."), pathlib.Path(url), pathlib.Path(target)

--- a/tests/zim/test_rewriting.py
+++ b/tests/zim/test_rewriting.py
@@ -215,6 +215,16 @@ def test_fix_links_in_html(html_str, pattern, expected_count):
     assert fix_links_in_html("A/welcome", html_str).count(pattern) == expected_count
 
 
+def test_fix_links_in_html_no_target():
+    # ensure that when no target is present, correct redirection is made
+    assert (
+        fix_links_in_html(
+            "A/hello/question", '<html><head></head><body><img src=""/></body></html>'
+        )
+        == '<html><head></head><body><img src="../../A/hello/question"/></body></html>'
+    )
+
+
 def test_fix_links_in_html_file(tmp_path, html_str):
     # make sure we raise on missing param (url or root mandatory)
     with pytest.raises(ValueError):


### PR DESCRIPTION
This fixes #53 by correctly rewriting of links with empty target. Also adds a test for the same.