### PR TITLE
Add YoutubeDownloader class in download.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * fixed rewriting of links with empty target
 * added support for image optimization using `zimscraperlib.image.optimization` for webp, gif, jpeg and png formats
 * added `format_for()` in `zimscraperlib.image.probing` to get PIL image format from the suffix
+* added `YoutubeDownloader` in `download.py` for downloading youtube videos with a constant number of threads
 
 # 1.3.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ libzim>=0.0.3.post0,<0.1
 beautifulsoup4>=4.9.1,<4.10
 lxml>=4.5.2,<4.6
 optimize-images==1.3.6
+# youtube-dl should be updated as frequently as possible
+youtube_dl

--- a/src/zimscraperlib/download.py
+++ b/src/zimscraperlib/download.py
@@ -26,6 +26,12 @@ class YoutubeDownloader:
 
         self.executor = ThreadPoolExecutor(max_workers=threads)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.shutdown()
+
     def shutdown(self) -> None:
         """ shuts down the executor """
 

--- a/src/zimscraperlib/download.py
+++ b/src/zimscraperlib/download.py
@@ -5,7 +5,7 @@
 import subprocess
 import pathlib
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional, Tuple
+from typing import Optional
 
 import requests
 import youtube_dl
@@ -40,7 +40,7 @@ class YoutubeDownloader:
 
     def run_youtube_dl(
         self, url: str, fpath: pathlib.Path, extra_options: Optional[dict] = {}
-    ) -> Tuple[bool, pathlib.Path]:
+    ) -> pathlib.Path:
         audext, vidext = {"webm": ("webm", "webm"), "mp4": ("m4a", "mp4")}[
             self.video_format
         ]
@@ -59,7 +59,7 @@ class YoutubeDownloader:
                 if content.is_file() and content.name.startswith(
                     f"{output_file_name}."
                 ):
-                    return True, content
+                    return content
 
     def download(
         self,
@@ -67,8 +67,7 @@ class YoutubeDownloader:
         preferred_fpath: pathlib.Path,
         extra_options: Optional[dict] = {},
     ) -> bool:
-        """Downloads a video using run_youtube_dl on the initialized executor and returns whether downloaded
-        and the path to the downloaded file.
+        """Downloads a video using run_youtube_dl on the initialized executor and returns the path to the downloaded file.
 
         Arguments:
         video: The url/video ID of the video to download.

--- a/src/zimscraperlib/download.py
+++ b/src/zimscraperlib/download.py
@@ -19,8 +19,6 @@ class YoutubeDownloader:
     a higher number of workers. The shutdown method must be run explicitly to
     free any occupied resources"""
 
-    executor = None
-
     def __init__(self, threads: Optional[int] = 2) -> None:
         """Initialize the class
         Arguments:
@@ -33,14 +31,14 @@ class YoutubeDownloader:
 
         self.executor.shutdown(wait=True)
 
-    def __run_youtube_dl(self, url: str, options: dict) -> None:
+    def _run_youtube_dl(self, url: str, options: dict) -> None:
         with youtube_dl.YoutubeDL(options) as ydl:
             ydl.download([url])
 
     def download(
         self,
         url: str,
-        options: Optional[dict] = {},
+        options: Optional[dict],
     ) -> bool:
         """Downloads a video using run_youtube_dl on the initialized executor.
 
@@ -48,7 +46,7 @@ class YoutubeDownloader:
         url: The url/video ID of the video to download.
         options: A dict containing any options that you want to pass directly to youtube_dl"""
 
-        future = self.executor.submit(self.__run_youtube_dl, url, options)
+        future = self.executor.submit(self._run_youtube_dl, url, options)
         if not future.exception():
             # return the result
             return future.result()

--- a/src/zimscraperlib/download.py
+++ b/src/zimscraperlib/download.py
@@ -3,13 +3,108 @@
 # vim: ai ts=4 sts=4 et sw=4 nu
 
 import subprocess
+import pathlib
+from concurrent.futures import ThreadPoolExecutor
+from typing import Optional, Tuple
 
 import requests
+import youtube_dl
 
 from . import logger
 
 
-def save_file(url, fpath, timeout=30, retries=5):
+class YoutubeDownloader:
+    """A class to download youtube videos using youtube_dl, on a ThreadPoolExecutor
+    maintaining a specified number of workers, even when executed parallely with
+    a higher number of workers. The shutdown method must be run explicitly to
+    free any occupied resources"""
+
+    executor = None
+    video_format = None
+
+    def __init__(
+        self, video_format: Optional[str] = "mp4", threads: Optional[int] = 2
+    ) -> None:
+        """Initialize the class
+        Arguments:
+        video_format : One of the video formats used by the scraper (used to generate youtube_dl options)
+        threads: The max number of workers for the executor"""
+
+        self.executor = ThreadPoolExecutor(max_workers=threads)
+        self.video_format = video_format
+
+    def shutdown(self) -> None:
+        """ shuts down the executor """
+
+        self.executor.shutdown(wait=True)
+
+    def run_youtube_dl(
+        self, url: str, fpath: pathlib.Path, extra_options: Optional[dict] = {}
+    ) -> Tuple[bool, pathlib.Path]:
+        audext, vidext = {"webm": ("webm", "webm"), "mp4": ("m4a", "mp4")}[
+            self.video_format
+        ]
+        output_file_name = fpath.name.replace(fpath.suffix, "")
+        options = {
+            "outtmpl": str(fpath.parent.joinpath(f"{output_file_name}.%(ext)s")),
+            "preferredcodec": self.video_format,
+            "format": f"best[ext={vidext}]/bestvideo[ext={vidext}]+bestaudio[ext={audext}]/best",
+            "retries": 20,
+            "fragment-retries": 50,
+        }
+        options.update(extra_options)
+        with youtube_dl.YoutubeDL(options) as ydl:
+            ydl.download([url])
+            for content in fpath.parent.iterdir():
+                if content.is_file() and content.name.startswith(
+                    f"{output_file_name}."
+                ):
+                    return True, content
+
+    def download(
+        self,
+        video: str,
+        preferred_fpath: pathlib.Path,
+        extra_options: Optional[dict] = {},
+    ) -> bool:
+        """Downloads a video using run_youtube_dl on the initialized executor and returns whether downloaded
+        and the path to the downloaded file.
+
+        Arguments:
+        video: The url/video ID of the video to download.
+        preferred_path: The preferred path to save the videos to. Note that the actual
+            downloaded path may be different (due to unavailability of video in certain formats)
+            and the actual downloaded path is returned by the method if the download is successful
+        extra_options: A dict containing any extra options that you want to pass directly to youtube_dl"""
+
+        url = video
+
+        # ensure url is in correct format
+        if not video.startswith("https://"):
+            if "youtube.com" in video or "youtu.be" in video:
+                url = f"https://{video}"
+            else:
+                url = f"https://youtube.com/watch?v={video}"
+
+        # run youtube_dl on the executor
+        print(url)
+        print(preferred_fpath)
+        future = self.executor.submit(
+            self.run_youtube_dl, url, preferred_fpath, extra_options
+        )
+        if not future.exception():
+            # return the result
+            return future.result()
+        # raise the exception
+        raise future.exception()
+
+
+def save_file(
+    url: str,
+    fpath: pathlib.Path,
+    timeout: Optional[int] = 30,
+    retries: Optional[int] = 5,
+) -> requests.structures.CaseInsensitiveDict:
     """download a file from its URL, and return headers
 
     Only recommended to be used with small files/HTMLs"""
@@ -29,7 +124,7 @@ def save_file(url, fpath, timeout=30, retries=5):
                 raise exc
 
 
-def save_large_file(url, fpath):
+def save_large_file(url: str, fpath: pathlib.Path) -> None:
     """ download a binary file from its URL, using wget """
     subprocess.run(
         [

--- a/tests/download/test_download.py
+++ b/tests/download/test_download.py
@@ -100,8 +100,7 @@ def test_large_download_https(tmp_path, valid_https_url):
 def test_youtube_download_serial(url, filename, tmp_path):
     yt_downloader = YoutubeDownloader(threads=1)
     fpath = tmp_path / filename
-    downloaded, downloaded_file = yt_downloader.download(url, fpath)
-    assert downloaded is True
+    downloaded_file = yt_downloader.download(url, fpath)
     assert downloaded_file.exists()
     yt_downloader.shutdown()
 
@@ -109,8 +108,7 @@ def test_youtube_download_serial(url, filename, tmp_path):
 @pytest.mark.slow
 def test_youtube_download_parallel(tmp_path):
     def download_and_assert(url, video_path, yt_downloader):
-        downloaded, downloaded_file = yt_downloader.download(url, video_path)
-        assert downloaded is True
+        downloaded_file = yt_downloader.download(url, video_path)
         assert downloaded_file.exists()
 
     yt_downloader = YoutubeDownloader(threads=2)

--- a/tests/download/test_download.py
+++ b/tests/download/test_download.py
@@ -151,3 +151,17 @@ def test_youtube_download_error(tmp_path):
     with pytest.raises(Exception):
         yt_downloader.download("11", BestMp4.get_options())
     yt_downloader.shutdown()
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "nb_workers",
+    [
+        1,
+        2,
+    ],
+)
+def test_youtube_download_contextmanager(nb_workers):
+    with YoutubeDownloader(threads=nb_workers) as yt_downloader:
+        assert yt_downloader.executor._max_workers == nb_workers
+        yt_downloader.download("Bc5QSUhL6co", BestMp4.get_options())


### PR DESCRIPTION
This adds a `YoutubeDownloader` class in `download.py` to download youtube videos on a constant number of threads. It has a method called `download()` which allows it to work like a normal serial function that can be then parallelized in the scrapers. However, it downloads on its own executor, hence, the number of workers actually downloading the videos gets reduced to the limit that is set during initialization.

The YoutubeDownloader has the following members -
- `executor` - A ThreadPoolExecutor which is initialized with a limited number of threads
- `video_format` - same as what we use in the scrapers (both webm and mp4 supported)

The `YoutubeDownloader` has the following methods -
- `__init__()` - Used to initialize the `executor` and the `video_format` 
- `shutdown()` - Used to shutdown the executor properly and must be called explicitly when there's no use of this class
- `run_youtube_dl()` - The method which downloads the videos using `youtube_dl`
- `download()`  - A method to run the `run_youtube_dl()` method on the executor with correct URL and return its return value or raise an exception

We can run the download() method parallely on several number of threads, but videos will download in a fixed number of threads. We can do it something like this (a similar test is also there) -
```python
    def download_video_and_convert(url, video_path, yt_downloader):
        # check if in the cache
        # download if not in cache
        downloaded_file = yt_downloader.download(url, video_path)
        # convert if necessary

    yt_downloader = YoutubeDownloader(threads=2)
    videos_list = [(url, video_path), (url, video_path) ... ]
    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
        fs = [
            executor.submit(download_video_and_convert, url, video_path, yt_downloader)
            for url, video_path in videos_list
        ]
        done, not_done = concurrent.futures.wait(
            fs, return_when=concurrent.futures.ALL_COMPLETED
        )
    yt_downloader.shutdown()
    # continue scraper work
```
