### PR TITLE
Prevent import errors while importing PIL.Image

### DIFF
--- a/src/zimscraperlib/image/__init__.py
+++ b/src/zimscraperlib/image/__init__.py
@@ -5,11 +5,11 @@
 import pathlib
 from typing import Optional
 
-import PIL
+from PIL import Image
 
 
 def save_image(
-    src: PIL.Image,
+    src: Image,
     dst: pathlib.Path,
     fmt: Optional[str] = None,
     **params: Optional[dict]

--- a/src/zimscraperlib/image/__init__.py
+++ b/src/zimscraperlib/image/__init__.py
@@ -9,10 +9,7 @@ from PIL import Image
 
 
 def save_image(
-    src: Image,
-    dst: pathlib.Path,
-    fmt: Optional[str] = None,
-    **params: Optional[dict]
+    src: Image, dst: pathlib.Path, fmt: Optional[str] = None, **params: Optional[dict]
 ) -> None:
     """ PIL.Image.save() wrapper setting default parameters """
     args = {"JPEG": {"quality": 100}, "PNG": {}}.get(fmt, {})


### PR DESCRIPTION
Import the Image module correctly from PIL instead of searching an attribute in an empty stub