### PR TITLE
Add wait parameter in YoutubeDownloader.download()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.3.4.dev0
 
-* n/a
+* added `wait` option in `YoutubeDownloader` to allow parallelism while using context manager
 
 # 1.3.3
 

--- a/src/zimscraperlib/download.py
+++ b/src/zimscraperlib/download.py
@@ -4,8 +4,8 @@
 
 import subprocess
 import pathlib
-from concurrent.futures import ThreadPoolExecutor
-from typing import Optional
+from concurrent.futures import ThreadPoolExecutor, Future
+from typing import Optional, Union
 
 import requests
 import youtube_dl
@@ -45,14 +45,18 @@ class YoutubeDownloader:
         self,
         url: str,
         options: Optional[dict],
-    ) -> bool:
+        wait: Optional[bool] = True,
+    ) -> Union[bool, Future]:
         """Downloads a video using run_youtube_dl on the initialized executor.
 
         Arguments:
         url: The url/video ID of the video to download.
-        options: A dict containing any options that you want to pass directly to youtube_dl"""
+        options: A dict containing any options that you want to pass directly to youtube_dl
+        wait: A boolean to specify whether to wait for completion. In case wait is False, the method would return a Future object"""
 
         future = self.executor.submit(self._run_youtube_dl, url, options)
+        if not wait:
+            return future
         if not future.exception():
             # return the result
             return future.result()

--- a/tests/download/test_download.py
+++ b/tests/download/test_download.py
@@ -164,6 +164,7 @@ def test_youtube_download_error(tmp_path):
 def test_youtube_download_contextmanager(nb_workers, videos, tmp_path):
     with YoutubeDownloader(threads=nb_workers) as yt_downloader:
         assert yt_downloader.executor._max_workers == nb_workers
+        yt_downloader.download("Bc5QSUhL6co", BestMp4.get_options())
         fs = [
             yt_downloader.download(
                 video, BestMp4.get_options(target_dir=tmp_path), wait=False


### PR DESCRIPTION
This fixes #61 by adding a `wait` parameter in `YoutubeDownloader.download()` which allows to disable waiting for the completion of the current job and return a `Future` object in that case. The usage in the tests is also fixed.