### PR TITLE
Handle wrong extension in optimize_image()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.3.4.dev0
 
 * added `wait` option in `YoutubeDownloader` to allow parallelism while using context manager
+- do not use extension for finding format in `ensure_matches()` in `image.optimization` module
 
 # 1.3.3
 

--- a/src/zimscraperlib/image/optimization.py
+++ b/src/zimscraperlib/image/optimization.py
@@ -29,7 +29,7 @@ from typing import Optional, Tuple, Union
 
 from optimize_images.data_structures import Task
 from optimize_images.do_optimization import do_optimization
-from PIL import Image, UnidentifiedImageError
+from PIL import Image
 
 from . import save_image
 from .convertion import convert_image
@@ -70,13 +70,7 @@ def ensure_matches(
 ) -> None:
     """ Raise ValueError if src is not of image type `fmt` """
 
-    detected_fmt = None
-    try:
-        detected_fmt = format_for(src, from_suffix=False)
-    except UnidentifiedImageError:
-        # fall back on suffix checking if can't determine format
-        detected_fmt = format_for(src)
-    if detected_fmt != fmt:
+    if format_for(src, from_suffix=False) != fmt:
         raise ValueError(f"{src} is not of format {fmt}")
 
 

--- a/src/zimscraperlib/image/optimization.py
+++ b/src/zimscraperlib/image/optimization.py
@@ -29,7 +29,7 @@ from typing import Optional, Tuple, Union
 
 from optimize_images.data_structures import Task
 from optimize_images.do_optimization import do_optimization
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 
 from . import save_image
 from .convertion import convert_image
@@ -70,7 +70,13 @@ def ensure_matches(
 ) -> None:
     """ Raise ValueError if src is not of image type `fmt` """
 
-    if format_for(src) != fmt:
+    detected_fmt = None
+    try:
+        detected_fmt = format_for(src, from_suffix=False)
+    except UnidentifiedImageError:
+        # fall back on suffix checking if can't determine format
+        detected_fmt = format_for(src)
+    if detected_fmt != fmt:
         raise ValueError(f"{src} is not of format {fmt}")
 
 

--- a/tests/download/test_download.py
+++ b/tests/download/test_download.py
@@ -164,7 +164,7 @@ def test_youtube_download_error(tmp_path):
 def test_youtube_download_contextmanager(nb_workers, videos, tmp_path):
     with YoutubeDownloader(threads=nb_workers) as yt_downloader:
         assert yt_downloader.executor._max_workers == nb_workers
-        yt_downloader.download("Bc5QSUhL6co", BestMp4.get_options())
+        yt_downloader.download("Bc5QSUhL6co", BestMp4.get_options(target_dir=tmp_path))
         fs = [
             yt_downloader.download(
                 video, BestMp4.get_options(target_dir=tmp_path), wait=False

--- a/tests/image/test_image.py
+++ b/tests/image/test_image.py
@@ -491,6 +491,7 @@ def test_optimize_webp_gif_failure(tmp_path, suffix, func):
 
     # make dummy dst to simulate dst being made and
     # after exception dst cleanup code running properly
+    src.touch()
     dst.touch()
 
     with pytest.raises(Exception):

--- a/tests/image/test_image.py
+++ b/tests/image/test_image.py
@@ -480,20 +480,23 @@ def test_optimize_images_task_failure(tmp_path, font):
     assert not dst.exists()
 
 
-@pytest.mark.parametrize(
-    "suffix,func",
-    [(".webp", optimize_webp), (".gif", optimize_gif)],
-)
-def test_optimize_webp_gif_failure(tmp_path, suffix, func):
-    # send an file which does not exist
-    src = tmp_path / f"src{suffix}"
-    dst = tmp_path / f"out{suffix}"
+def test_optimize_webp_gif_failure(tmp_path, webp_image, gif_image):
+    dst = tmp_path.joinpath("image.img")
 
-    # make dummy dst to simulate dst being made and
-    # after exception dst cleanup code running properly
-    src.touch()
-    dst.touch()
-
+    # webp
     with pytest.raises(Exception):
-        func(src, dst)
+        optimize_webp(webp_image, dst, lossless="bad")
     assert not dst.exists()
+
+    # gif
+    dst.touch()  # fake temp file created during optim (actually fails before)
+    with pytest.raises(Exception):
+        optimize_gif(gif_image, dst, optimize_level="bad")
+    assert not dst.exists()
+
+
+def test_wrong_extension_optim(tmp_path, png_image):
+    dst = tmp_path.joinpath("image.jpg")
+    shutil.copy(png_image, dst)
+    with pytest.raises(Exception):
+        optimize_jpeg(dst, dst)


### PR DESCRIPTION
This fixes #64 by handling wrong extension while optimizing images. It creates a copy of the original file with correct extension if wrong extension is found. 

Also, unrelated - Use correct directory in the yt_downloader context manager test to not have files downloaded in workdir,