### PR TITLE
Add high quality presets for WebM and Mp4 encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 1.3.4.dev0
 
 * added `wait` option in `YoutubeDownloader` to allow parallelism while using context manager
-- do not use extension for finding format in `ensure_matches()` in `image.optimization` module
+* do not use extension for finding format in `ensure_matches()` in `image.optimization` module
+* added `VideoWebmHigh` and `VideoMp4High` presets for high quality WebM and Mp4 convertion respectively
 
 # 1.3.3
 

--- a/src/zimscraperlib/video/presets.py
+++ b/src/zimscraperlib/video/presets.py
@@ -70,3 +70,32 @@ class VideoMp4Low(Config):
         "-b:a": "48k",  # target audio bitrate
         "-movflags": "+faststart",  # extra flag
     }
+
+
+class VideoWebmHigh(Config):
+    """High Quality webm video
+
+    25 constant quality"""
+
+    VERSION = 1
+
+    options = {
+        "-codec:v": "libvpx",  # video codec
+        "-codec:a": "libvorbis",  # audio codec
+        "-crf": "25",  # constant quality, lower value gives better quality and larger files
+        "-b:v": "0",  # must be passed for using constant quality mode via -cbr for this codec
+    }
+
+
+class VideoMp4High(Config):
+    """Low Quality mp4 video
+
+    20 constant quality"""
+
+    VERSION = 1
+
+    options = {
+        "-codec:v": "h264",  # video codec
+        "-codec:a": "aac",  # audio codec
+        "-crf": "20",  # constant quality, lower value gives better quality and larger files
+    }

--- a/tests/video/test_video.py
+++ b/tests/video/test_video.py
@@ -9,7 +9,13 @@ import subprocess
 import shutil
 
 from zimscraperlib.video import Config, get_media_info, reencode
-from zimscraperlib.video.presets import VoiceMp3Low, VideoWebmLow, VideoMp4Low
+from zimscraperlib.video.presets import (
+    VoiceMp3Low,
+    VideoWebmLow,
+    VideoMp4Low,
+    VideoWebmHigh,
+    VideoMp4High,
+)
 
 
 def copy_media_and_reencode(temp_dir, src, dest, ffmpeg_args, test_files, **kwargs):
@@ -152,6 +158,32 @@ def test_preset_video_webm_low():
     assert idx != -1 and args[idx + 1] == "900k"
 
 
+def test_preset_video_webm_high():
+    config = VideoWebmHigh()
+    assert config.VERSION == 1
+    args = config.to_ffmpeg_args()
+    assert len(args) == 10
+    options_map = [
+        ("codec:v", "libvpx"),
+        ("codec:a", "libvorbis"),
+        ("b:v", "0"),
+        ("crf", "25"),
+    ]
+    for option, val in options_map:
+        idx = args.index(f"-{option}")
+        assert idx != -1
+        assert args[idx + 1] == val
+
+    # test updating values
+    config = VideoWebmHigh(**{"-crf": "51"})
+    config["-b:v"] = "300k"
+    args = config.to_ffmpeg_args()
+    idx = args.index("-crf")
+    assert idx != -1 and args[idx + 1] == "51"
+    idx = args.index("-b:v")
+    assert idx != -1 and args[idx + 1] == "300k"
+
+
 def test_preset_video_mp4_low():
     config = VideoMp4Low()
     assert config.VERSION == 1
@@ -183,6 +215,31 @@ def test_preset_video_mp4_low():
     assert idx != -1 and args[idx + 1] == "50000"
     idx = args.index("-bufsize")
     assert idx != -1 and args[idx + 1] == "900k"
+
+
+def test_preset_video_mp4_high():
+    config = VideoMp4High()
+    assert config.VERSION == 1
+    args = config.to_ffmpeg_args()
+    assert len(args) == 8
+    options_map = [
+        ("codec:v", "h264"),
+        ("codec:a", "aac"),
+        ("crf", "20"),
+    ]
+    for option, val in options_map:
+        idx = args.index(f"-{option}")
+        assert idx != -1
+        assert args[idx + 1] == val
+
+    # test updating values
+    config = VideoMp4Low(**{"-codec:v": "libx264"})
+    config["-crf"] = "11"
+    args = config.to_ffmpeg_args()
+    idx = args.index("-codec:v")
+    assert idx != -1 and args[idx + 1] == "libx264"
+    idx = args.index("-crf")
+    assert idx != -1 and args[idx + 1] == "11"
 
 
 def test_preset_voice_mp3_low():


### PR DESCRIPTION
This adds two new presets for high quality WebM and Mp4 encoding. These are `VideoWebmHigh` and `VideoMp4High`. Both use constant quality mode using `-cbr` and it is set to a value where we get quality similar to the source and a similar filesize too, The lower the value of `-cbr`, the higher the quality and the higher the filesize.