### PR TITLE
Add ability to return content as bytes in save_large_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.3.5.dev0
 
-* n/a
+* make `fpath` optional in `save_large_file` and return the downloaded content as `bytes` if no `fpath` is supplied
 
 # 1.3.4
 

--- a/src/zimscraperlib/download.py
+++ b/src/zimscraperlib/download.py
@@ -145,9 +145,14 @@ def save_file(
                 raise exc
 
 
-def save_large_file(url: str, fpath: pathlib.Path) -> None:
-    """ download a binary file from its URL, using wget """
-    subprocess.run(
+def save_large_file(
+    url: str, fpath: Optional[pathlib.Path] = None
+) -> Union[None, bytes]:
+    """download a binary file from its URL, using wget
+
+    If fpath is supplied, file gets written to the supplied path
+    If not, a byte-string is returned containing contents of the file"""
+    wget = subprocess.run(
         [
             "/usr/bin/env",
             "wget",
@@ -156,9 +161,13 @@ def save_large_file(url: str, fpath: pathlib.Path) -> None:
             "--retry-connrefused",
             "--random-wait",
             "-O",
-            str(fpath),
+            str(fpath) if fpath else "-",
             "-c",
             url,
         ],
         check=True,
+        stdout=subprocess.PIPE,
     )
+
+    if not fpath:
+        return wget.stdout

--- a/tests/download/test_download.py
+++ b/tests/download/test_download.py
@@ -96,6 +96,12 @@ def test_large_download_https(tmp_path, valid_https_url):
 
 
 @pytest.mark.slow
+def test_large_download_to_memory(valid_https_url):
+    downloaded_content = save_large_file(valid_https_url)
+    assert len(downloaded_content) == 5430
+
+
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "url,video_id",
     [


### PR DESCRIPTION
This removes the requirement of `fpath` in `save_large_file()` and instead return the downloaded content as bytes without writing to disk if no `fpath` is supplied. This does it by supplying `-` to `-O` in the call of `wget` which redirects the output to stdout.

This would be helpful in new scrapers like `kolibri2zim`