### PR TITLE
Stream downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.3.5.dev0
 
-* n/a
+* add `stream_file()` to stream content from a URL into a file or a `BytesIO` object
+* deprecated `save_file()`
 
 # 1.3.4
 

--- a/src/zimscraperlib/download.py
+++ b/src/zimscraperlib/download.py
@@ -2,10 +2,12 @@
 # -*- coding: utf-8 -*-
 # vim: ai ts=4 sts=4 et sw=4 nu
 
-import subprocess
+import io
 import pathlib
-from concurrent.futures import ThreadPoolExecutor, Future
+import subprocess
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Optional, Union
+from logging import Logger
 
 import requests
 import youtube_dl
@@ -120,31 +122,6 @@ class BestMp4(YoutubeConfig):
     }
 
 
-def save_file(
-    url: str,
-    fpath: pathlib.Path,
-    timeout: Optional[int] = 30,
-    retries: Optional[int] = 5,
-) -> requests.structures.CaseInsensitiveDict:
-    """download a file from its URL, and return headers
-
-    Only recommended to be used with small files/HTMLs"""
-
-    for left_attempts in range(retries, -1, -1):
-        try:
-            resp = requests.get(url, timeout=timeout)
-            resp.raise_for_status()
-            with open(fpath, "wb") as fp:
-                fp.write(resp.content)
-            return resp.headers
-        except requests.exceptions.RequestException as exc:
-            logger.debug(
-                f"Request for {url} failed ({left_attempts} attempts left)\n{exc}"
-            )
-            if left_attempts == 0:
-                raise exc
-
-
 def save_large_file(url: str, fpath: pathlib.Path) -> None:
     """ download a binary file from its URL, using wget """
     subprocess.run(
@@ -162,3 +139,131 @@ def save_large_file(url: str, fpath: pathlib.Path) -> None:
         ],
         check=True,
     )
+
+
+class ProgressReporter:
+    def __init__(self, writter):
+        self._current_size = 0
+        self.width = 60
+        self._last_line = None
+        self._writter = writter
+        self.reporthook(0, 0, 100)  # display empty bar as we start
+
+    def reporthook(self, chunk, chunk_size, total_size):
+        if chunk != 0:
+            self._current_size += chunk_size
+
+        avail_dots = self.width - 2
+        if total_size == -1:
+            line = "unknown size"
+        elif self._current_size >= total_size:
+            line = "[" + "." * avail_dots + "] 100%\n"
+        else:
+            ratio = min(float(self._current_size) / total_size, 1.0)
+            shaded_dots = min(int(ratio * avail_dots), avail_dots)
+            percent = min(int(ratio * 100), 100)
+            line = (
+                "["
+                + "." * shaded_dots
+                + " " * (avail_dots - shaded_dots)
+                + "] "
+                + str(percent)
+                + "%\r"
+            )
+
+        if line != self._last_line:
+            self._last_line = line
+            self._writter(line)
+
+
+
+def save_file(
+    url: str,
+    fpath: pathlib.Path,
+    timeout: Optional[int] = 30,
+    retries: Optional[int] = 5,
+) -> requests.structures.CaseInsensitiveDict:
+    """download a file from its URL, and return headers
+    Only recommended to be used with small files/HTMLs"""
+
+    for left_attempts in range(retries, -1, -1):
+        try:
+            resp = requests.get(url, timeout=timeout)
+            resp.raise_for_status()
+            with open(fpath, "wb") as fp:
+                fp.write(resp.content)
+            return resp.headers
+        except requests.exceptions.RequestException as exc:
+            logger.debug(
+                f"Request for {url} failed ({left_attempts} attempts left)\n{exc}"
+            )
+            if left_attempts == 0:
+                raise exc
+
+
+def stream_file(
+    url: str,
+    fpath: Optional[pathlib.Path] = None,
+    byte_stream: Optional[io.BytesIO] = None,
+    logger_obj: Optional[Logger] = None,
+    block_size: Optional[int] = 1024,
+    proxies: Optional[dict] = None,
+    only_first_block: Optional[bool] = False,
+    max_retries: Optional[int] = 5,
+) -> Union[int, requests.structures.CaseInsensitiveDict]:
+    """download an URL without blocking
+    - retries download on failure (with increasing wait delay)
+    - writes progress information to the logger"""
+
+    # if nothing provided
+    if not fpath and not byte_stream:
+        raise AttributeError("Either file path or a bytesIO object is needed")
+
+    if logger_obj is not None:
+        progress_reporter = ProgressReporter(logger.raw_std)
+
+    # prepare adapter so it retries on failure
+    session = requests.Session()
+    # retries up-to FAILURE_RETRIES whichever kind of listed error
+    retries = requests.packages.urllib3.util.retry.Retry(
+        total=max_retries,  # total number of retries
+        connect=max_retries,  # connection errors
+        read=max_retries,  # read errors
+        status=2,  # failure HTTP status (only those bellow)
+        redirect=False,  # don't fail on redirections
+        backoff_factor=30,  # sleep factor between retries
+        status_forcelist=[413, 429, 500, 502, 503, 504],
+    )
+
+    retry_adapter = requests.adapters.HTTPAdapter(max_retries=retries)
+    session.mount("http", retry_adapter)  # tied to http and https
+    resp = session.get(
+        url, stream=True, proxies=proxies,
+    )
+
+    total_size = int(resp.headers.get("content-length", 0))
+    # adjust if we are only requesting first block
+    if only_first_block and total_size > block_size:
+        total_size = block_size
+
+    total_downloaded = 0
+    if fpath is not None:
+        fp = open(fpath, "wb")
+    else:
+        fp = byte_stream
+
+    for data in resp.iter_content(block_size):
+        if logger_obj is not None:
+            progress_reporter.reporthook(data, block_size, total_size)
+        total_downloaded += len(data)
+        fp.write(data)
+
+        # stop downloading/reading if we're just testing first block
+        if only_first_block:
+            break
+
+    if fpath:
+        fp.close()
+    else:
+        fp.seek(0)
+    return total_downloaded, resp.headers

--- a/src/zimscraperlib/inputs.py
+++ b/src/zimscraperlib/inputs.py
@@ -7,7 +7,7 @@ import pathlib
 import tempfile
 
 from . import logger
-from .download import save_file
+from .download import stream_file
 
 
 def handle_user_provided_file(source=None, dest=None, in_dir=None, nocopy=False):
@@ -35,7 +35,7 @@ def handle_user_provided_file(source=None, dest=None, in_dir=None, nocopy=False)
 
     if source.startswith("http"):
         logger.debug(f"download {source} -> {dest}")
-        save_file(source, dest)
+        stream_file(url=source, fpath=dest)
     else:
         source = pathlib.Path(source).expanduser().resolve()
         if not source.exists():

--- a/tests/download/test_download.py
+++ b/tests/download/test_download.py
@@ -46,16 +46,19 @@ def test_invalid_url(tmp_path, invalid_url):
 
 
 def test_no_output_supplied(valid_http_url):
-    with pytest.raises(ValueError, match="Either file path or a bytesIO object is needed"):
+    with pytest.raises(
+        ValueError, match="Either file path or a bytesIO object is needed"
+    ):
         stream_file(url=valid_http_url)
 
 
-# @pytest.mark.slow
-# def test_show_progress(tmp_path, valid_http_url):
-#     dest_file = tmp_path / "favicon.ico"
-#     local_logger = getLogger()
-#     stream_file(url=valid_http_url, fpath=dest_file, logger_obj=local_logger)
-
+def test_first_block_download(valid_http_url):
+    byte_stream = io.BytesIO()
+    size, ret = stream_file(
+        url=valid_http_url, byte_stream=byte_stream, only_first_block=True
+    )
+    assert_headers(ret)
+    assert len(byte_stream.read()) == 3062
 
 
 @pytest.mark.slow
@@ -75,7 +78,7 @@ def test_save_https(tmp_path, valid_https_url):
 
 
 @pytest.mark.slow
-def test_stream_to_bytes(tmp_path, valid_https_url):
+def test_stream_to_bytes(valid_https_url):
     byte_stream = io.BytesIO()
     size, ret = stream_file(url=valid_https_url, byte_stream=byte_stream)
     assert_headers(ret)

--- a/tests/download/test_download.py
+++ b/tests/download/test_download.py
@@ -2,13 +2,14 @@
 # -*- coding: utf-8 -*-
 # vim: ai ts=4 sts=4 et sw=4 nu
 
+import io
 import pytest
 import requests
 import pathlib
 import concurrent.futures
 
 from zimscraperlib.download import (
-    save_file,
+    stream_file,
     save_large_file,
     YoutubeDownloader,
     BestWebm,
@@ -35,19 +36,19 @@ def get_dest_file(tmp_path):
 
 def test_missing_dest(tmp_path):
     with pytest.raises(TypeError):
-        save_file("http://some_url")
+        stream_file(url="http://some_url", byte_stream=io.BytesIO)
 
 
 def test_invalid_url(tmp_path, invalid_url):
     dest_file = tmp_path / "favicon.ico"
     with pytest.raises(requests.exceptions.ConnectionError):
-        save_file(invalid_url, dest_file)
+        stream_file(url=invalid_url, fpath=dest_file)
 
 
 @pytest.mark.slow
 def test_save_http(tmp_path, valid_http_url):
     dest_file = tmp_path / "favicon.ico"
-    ret = save_file(valid_http_url, dest_file)
+    size, ret = stream_file(valid_http_url, dest_file)
     assert_headers(ret)
     assert_downloaded_file(valid_http_url, dest_file)
 
@@ -55,7 +56,7 @@ def test_save_http(tmp_path, valid_http_url):
 @pytest.mark.slow
 def test_save_https(tmp_path, valid_https_url):
     dest_file = tmp_path / "favicon.ico"
-    ret = save_file(valid_https_url, dest_file)
+    size, ret = stream_file(url=valid_https_url, fpath=dest_file)
     assert_headers(ret)
     assert_downloaded_file(valid_https_url, dest_file)
 
@@ -64,21 +65,14 @@ def test_save_https(tmp_path, valid_https_url):
 def test_save_parent_folder_missing(tmp_path, valid_http_url):
     dest_file = tmp_path / "some-folder" / "favicon.ico"
     with pytest.raises(IOError):
-        save_file(valid_http_url, dest_file)
+        stream_file(url=valid_http_url, fpath=dest_file)
 
 
 @pytest.mark.slow
 def test_save_http_error(tmp_path, http_error_url):
     dest_file = tmp_path / "favicon.ico"
     with pytest.raises(requests.exceptions.HTTPError):
-        save_file(http_error_url, dest_file)
-
-
-@pytest.mark.slow
-def test_save_timeout(tmp_path, timeout_url):
-    dest_file = tmp_path / "favicon.ico"
-    with pytest.raises(requests.exceptions.RequestException):
-        save_file(timeout_url, dest_file, timeout=1)
+        stream_file(url=http_error_url, fpath=dest_file)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
This replaces save_file() with stream_file() which will allow streaming to a file or a bytesIO object

The function also allows downloading only a single block (of a specified size by using the `block_size` parameter) which can be useful for identifying file type if required. It returns the response headers and the total number of bytes downloaded. 

Tests are updated for the same.

not related - At this point, the unit tests fail due to the set-env command being deprecated. 