### PR TITLE
Ensure filename in StaticArticle is not None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * add `stream_file()` to stream content from a URL into a file or a `BytesIO` object
 * deprecated `save_file()`
-* ensure return type is string for filename in `StaticArticle`
+* fixed `add_binary` when used without an fpath (#69)
 
 # 1.3.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * add `stream_file()` to stream content from a URL into a file or a `BytesIO` object
 * deprecated `save_file()`
+* ensure return type is string for filename in `StaticArticle`
 
 # 1.3.4
 

--- a/src/zimscraperlib/zim/creator.py
+++ b/src/zimscraperlib/zim/creator.py
@@ -50,7 +50,7 @@ class StaticArticle(libzim.writer.Article):
             setattr(self, k, v)
 
     def get_url(self) -> str:
-        return getattr(self, "url")
+        return getattr(self, "url", "")
 
     def get_title(self) -> str:
         return getattr(self, "title", "")

--- a/src/zimscraperlib/zim/creator.py
+++ b/src/zimscraperlib/zim/creator.py
@@ -178,7 +178,7 @@ class Creator(libzim.writer.Creator):
             StaticArticle(
                 url=to_longurl(namespace, url),
                 mime_type=mime_type,
-                filename=str(fpath) if fpath is not None else None,
+                filename=str(fpath) if fpath is not None else "",
                 content=content,
                 index=should_index,
                 compress=should_compress,


### PR DESCRIPTION
Fixes #69 by not setting filename as `None` in StaticArticle object in `add_binary()`